### PR TITLE
🐛  投稿後にトップ画面に不要なローディングが表示されるエラーの解消

### DIFF
--- a/src/app/(pages)/(main)/page.tsx
+++ b/src/app/(pages)/(main)/page.tsx
@@ -85,7 +85,7 @@ export default function Home() {
     return (
         <>
             {(isError || isFetchingMoreEmotesError) && <DisplayErrorMessage error={handledError}></DisplayErrorMessage>}
-            {isPending && <LoadingSpin />}
+            {isPending && !hasEmoteSet && <LoadingSpin />}
             {emotes && <WordlessEmotes emotes={emotes}></WordlessEmotes>}
             {!isPending && (
                 <EndOfEmotes


### PR DESCRIPTION
## 概要
* 投稿後にトップ画面に不要なローディングが表示されるバグの解消

## 影響範囲

## テスト
* 単体テストが全て通ること

## 関連Issue
